### PR TITLE
Reimplement how sample data is supplied for analysis directory creation

### DIFF
--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -101,6 +101,26 @@ def setup(project_dir, user, PI, application=None, organism=None,
           samples_csv=None, top_dir=None):
     """
     Set up a new analysis directory for a Promethion project
+
+    The analysis directory will be called "<PROJECT>_analysis".
+
+    Information about the samples can be supplied via a CSV
+    file with the format:
+
+    ::
+
+        Header line
+        SAMPLE,BARCODE[,FLOWCELL]
+
+    Arguments:
+      project_dir (str): path to PromethION project
+      user (str): user(s) associated with the project
+      PI (str): principal investigator(s)
+      application (str): experimental application(s)
+      organism (str): associated origanism(s)
+      samples_csv (str): path to CSV file with sample information
+      top_dir (str): directory to make analysis directory
+        under (defaults to current directory)
     """
     # Read source project data
     project_name = os.path.basename(os.path.normpath(project_dir))

--- a/bcf_nanopore/test/test_analysis.py
+++ b/bcf_nanopore/test/test_analysis.py
@@ -54,22 +54,15 @@ class TestProjectAnalysisDir(unittest.TestCase):
         self.assertTrue(Path(analysis_dir_path).joinpath("ScriptCode").is_dir())
         self.assertTrue(Path(analysis_dir_path).joinpath("logs").is_dir())
 
-    def test_project_analysis_dir_create_with_samplesheet(self):
+    def test_project_analysis_dir_create_with_samples(self):
         """
-        ProjectAnalysisDir: create new analysis directory with sample sheet
+        ProjectAnalysisDir: create new analysis directory with samples
         """
         data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
         data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f", run="PG1-4_20240513", pool="PG1-2")
         data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
                                    flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
         project_dir = data_dir.create(self.wd)
-        sample_sheet = Path(self.wd).joinpath("sample_sheet.csv")
-        sample_sheet.write_text("""Sample name,Barcode,Flow cell ID
-PG1,NB03,PAW15419
-PG2,NB04,
-PG3,NB05,PAW15420
-PG4,NB06,
-""")
         analysis_dir_path = str(Path(self.wd).joinpath("PromethION_Project_001_PerGynt_analysis"))
         analysis_dir = ProjectAnalysisDir(analysis_dir_path)
         self.assertFalse(analysis_dir.exists())
@@ -78,7 +71,10 @@ PG4,NB06,
                             PI="Henrik Ibsen",
                             application="Methylation study",
                             organism="Human",
-                            sample_sheet=str(sample_sheet))
+                            samples=[("PG1", "NB03", "PAW15419"),
+                                     ("PG2", "NB04", "PAW15419"),
+                                     ("PG3", "NB05", "PAW15420"),
+                                     ("PG4", "NB06", "PAW15420")])
         self.assertTrue(analysis_dir.exists())
         self.assertEqual(analysis_dir.path, analysis_dir_path)
         self.assertEqual(analysis_dir.info.name, "PromethION_Project_001_PerGynt")

--- a/bcf_nanopore/test/test_cli.py
+++ b/bcf_nanopore/test/test_cli.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+# Tests for the 'cli' module
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from bcf_nanopore.analysis import ProjectAnalysisDir
+from bcf_nanopore.mock import MockPromethionDataDir
+from bcf_nanopore.cli import setup as cli_setup
+from bcf_nanopore.cli import fetch as cli_fetch
+
+class TestSetupCommand(unittest.TestCase):
+
+    def setUp(self):
+        self.wd = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if Path(self.wd).exists():
+            shutil.rmtree(self.wd)
+
+    def test_setup(self):
+        """
+        setup: create new analysis directory
+        """
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f", run="PG1-4_20240513", pool="PG1-2")
+        data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
+                                   flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
+        project_dir = data_dir.create(self.wd)
+        analysis_dir_path = str(Path(self.wd).joinpath("PromethION_Project_001_PerGynt_analysis"))
+        cli_setup(project_dir, "Per Gynt", "Henrik Ibsen", "Methylation study",
+                  "Human", top_dir=self.wd)
+        analysis_dir = ProjectAnalysisDir(analysis_dir_path)
+        self.assertTrue(analysis_dir.exists())
+        self.assertEqual(analysis_dir.path, analysis_dir_path)
+        self.assertEqual(analysis_dir.info.name, "PromethION_Project_001_PerGynt")
+        self.assertEqual(analysis_dir.info.id, "PROMETHION#001")
+        self.assertEqual(analysis_dir.info.platform, "promethion")
+        self.assertEqual(analysis_dir.info.data_dir, project_dir)
+        self.assertEqual(analysis_dir.info.user, "Per Gynt")
+        self.assertEqual(analysis_dir.info.PI, "Henrik Ibsen")
+        self.assertEqual(analysis_dir.info.application, "Methylation study")
+        self.assertEqual(analysis_dir.info.organism, "Human")
+        self.assertTrue(Path(analysis_dir_path).joinpath("README").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("project.info").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("PromethION_Project_001_PerGynt.tsv").exists())
+        self.assertFalse(Path(analysis_dir_path).joinpath("samples.tsv").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("ScriptCode").is_dir())
+        self.assertTrue(Path(analysis_dir_path).joinpath("logs").is_dir())
+
+    def test_setup_with_samplesheet(self):
+        """
+        setup: create new analysis directory with samples CSV file
+        """
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f", run="PG1-4_20240513", pool="PG1-2")
+        data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
+                                   flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
+        project_dir = data_dir.create(self.wd)
+        samples_csv = Path(self.wd).joinpath("samples.csv")
+        samples_csv.write_text("""Sample name,Barcode,Flow cell ID
+PG1,NB03,PAW15419
+PG2,NB04,
+PG3,NB05,PAW15420
+PG4,NB06,
+""")
+        analysis_dir_path = str(Path(self.wd).joinpath("PromethION_Project_001_PerGynt_analysis"))
+        cli_setup(project_dir, "Per Gynt", "Henrik Ibsen", "Methylation study",
+                  "Human", samples_csv=str(samples_csv), top_dir=self.wd)
+        analysis_dir = ProjectAnalysisDir(analysis_dir_path)
+        self.assertTrue(analysis_dir.exists())
+        self.assertEqual(analysis_dir.path, analysis_dir_path)
+        self.assertEqual(analysis_dir.info.name, "PromethION_Project_001_PerGynt")
+        self.assertEqual(analysis_dir.info.id, "PROMETHION#001")
+        self.assertEqual(analysis_dir.info.platform, "promethion")
+        self.assertEqual(analysis_dir.info.data_dir, project_dir)
+        self.assertEqual(analysis_dir.info.user, "Per Gynt")
+        self.assertEqual(analysis_dir.info.PI, "Henrik Ibsen")
+        self.assertEqual(analysis_dir.info.application, "Methylation study")
+        self.assertEqual(analysis_dir.info.organism, "Human")
+        self.assertTrue(Path(analysis_dir_path).joinpath("README").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("project.info").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("PromethION_Project_001_PerGynt.tsv").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("samples.tsv").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("ScriptCode").is_dir())
+        self.assertTrue(Path(analysis_dir_path).joinpath("logs").is_dir())


### PR DESCRIPTION
Reimplements how sample data is supplied for analysis directory creation, specifically:

- The `ProjectAnalysisDir.create()` method (in the `analysis` module) now expects sample information to be supplied via a list as one of its optional arguments
- Extracting the sample information from an external CSV has moved from that method and is now handled in the `setup` function (in the `cli` module) which implements the `setup` command.