### PR TITLE
Enable 'fetch' subcommand to use a job runner

### DIFF
--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -339,6 +339,8 @@ def bcf_nanopore_main():
                            "directory will be created under this)")
     fetch_cmd.add_argument('--dry-run', action="store_true",
                            help="dry run only (no data will be copied)")
+    fetch_cmd.add_argument('-r', '--runner', action="store",
+                           help="job runner to use (optional)")
 
     # Process command line
     args = p.parse_args()
@@ -356,4 +358,5 @@ def bcf_nanopore_main():
         report(args.analysis_dir, mode=args.mode, fields=args.fields,
                template=args.template, out_file=args.out_file)
     elif args.command == "fetch":
-        fetch(args.project_dir, args.dest, dry_run=args.dry_run)
+        fetch(args.project_dir, args.dest, dry_run=args.dry_run,
+              runner=args.runner)

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -8,9 +8,11 @@ import os
 import json
 from argparse import ArgumentParser
 from auto_process_ngs.command import Command
+from bcftbx.JobRunner import fetch_runner
 from .analysis import ProjectAnalysisDir
 from .nanopore.promethion import BasecallsMetadata
 from .nanopore.promethion import ProjectDir
+from .utils import execute_command
 from .utils import fmt_value
 from .utils import fmt_yes_no
 
@@ -200,10 +202,28 @@ def report(path, mode="summary", fields=None, template=None, out_file=None):
             fp.write(report_text + '\n')
 
 
-def fetch(project_dir, target_dir, dry_run=False):
+def fetch(project_dir, target_dir, dry_run=False, runner=None):
     """
     Fetch the BAM files and reports for a Promethion run
+
+    Arguments:
+      project_dir (str): path to PromethION project
+        (can local or remote)
+      target_dir (str): path to top-level directory to
+        copy project files into
+      dry_run (bool): if True then do dry run rsync only
+        (default is to actually fetch the data)
+      runner (str): job runner definition to use to
+        execute the fetch operations
     """
+    # Clean the project dir path
+    project_dir = project_dir.rstrip(os.sep)
+    # Project name
+    project_name = os.path.basename(project_dir)
+    # Fetch job runner
+    if runner is not None:
+        runner = fetch_runner(runner)
+        print(f"Using job runner '{runner}'")
     # Example rsync to only fetch BAM and index files:
     # rsync --dry-run -av -m --include="*/" \
     # --include="bam_pass/*/*.bam" --include="bam_pass/*/*.bai" \
@@ -224,9 +244,9 @@ def fetch(project_dir, target_dir, dry_run=False):
                         project_dir,
                         target_dir)
     print("Transferring BAM files with command: %s" % rsync_bams)
-    status = rsync_bams.run_subprocess()
+    status = execute_command(rsync_bams, runner=runner)
     if status != 0:
-        pass
+        raise Exception("fetch: failed to transfer data")
     # Example to fetch reports and sample sheets:
     # rsync --dry-run -av -m --include="*/" --include="report_*" \
     # --include="sample_sheet_*" --exclude="*" \
@@ -243,9 +263,9 @@ def fetch(project_dir, target_dir, dry_run=False):
                            project_dir,
                            target_dir)
     print("Transferring report files with command: %s" % rsync_reports)
-    status = rsync_reports.run_subprocess()
+    status = execute_command(rsync_reports, runner=runner)
     if status != 0:
-        pass
+        raise Exception("fetch: failed to transfer reports")
 
 
 def bcf_nanopore_main():

--- a/bcf_nanopore/test/test_cli.py
+++ b/bcf_nanopore/test/test_cli.py
@@ -87,3 +87,64 @@ PG4,NB06,
         self.assertTrue(Path(analysis_dir_path).joinpath("samples.tsv").exists())
         self.assertTrue(Path(analysis_dir_path).joinpath("ScriptCode").is_dir())
         self.assertTrue(Path(analysis_dir_path).joinpath("logs").is_dir())
+
+
+class TestFetchCommand(unittest.TestCase):
+
+    def setUp(self):
+        self.wd = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if Path(self.wd).exists():
+            shutil.rmtree(self.wd)
+
+    def test_fetch(self):
+        """
+        fetch: copy PromethION data
+        """
+        # Make source data
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f", run="PG1-4_20240513", pool="PG1-2")
+        data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
+                                   flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
+        source_dir = os.path.join(self.wd, "source")
+        os.mkdir(source_dir)
+        project_dir = data_dir.create(source_dir)
+        # Fetch subset
+        target_dir = os.path.join(self.wd, "target")
+        cli_fetch(project_dir, target_dir)
+        self.assertTrue(Path(target_dir).joinpath("PromethION_Project_001_PerGynt").exists())
+
+    def test_fetch_trailing_slash_on_source_name(self):
+        """
+        fetch: copy PromethION data (trailing slash on source name)
+        """
+        # Make source data
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f", run="PG1-4_20240513", pool="PG1-2")
+        data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
+                                   flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
+        source_dir = os.path.join(self.wd, "source")
+        os.mkdir(source_dir)
+        project_dir = data_dir.create(source_dir)
+        # Fetch subset
+        target_dir = os.path.join(self.wd, "target")
+        cli_fetch(project_dir + os.sep, target_dir)
+        self.assertTrue(Path(target_dir).joinpath("PromethION_Project_001_PerGynt").exists())
+
+    def test_fetch_using_jobrunner(self):
+        """
+        fetch: copy PromethION data using job runner
+        """
+        # Make source data
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f", run="PG1-4_20240513", pool="PG1-2")
+        data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
+                                   flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
+        source_dir = os.path.join(self.wd, "source")
+        os.mkdir(source_dir)
+        project_dir = data_dir.create(source_dir)
+        # Fetch subset using job runner
+        target_dir = os.path.join(self.wd, "target")
+        cli_fetch(project_dir, target_dir, runner="SimpleJobRunner(join_logs=True)")
+        self.assertTrue(Path(target_dir).joinpath("PromethION_Project_001_PerGynt").exists())

--- a/bcf_nanopore/utils.py
+++ b/bcf_nanopore/utils.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 #
 #     utils.py: utility classes and functions
-#     Copyright (C) University of Manchester 2024 Peter Briggs
+#     Copyright (C) University of Manchester 2024-2025 Peter Briggs
 #
 
 """
 Utility classes and functions
 """
 
+import os
 import logging
-
+from auto_process_ngs.simple_scheduler import SchedulerJob
 from bcftbx.TabFile import TabFile
 
 # Module specific logger
@@ -262,6 +263,62 @@ class MetadataTabFile(TabFile):
         return (name.lstrip('#') in
                 [entry[self.index].lstrip('#')
                  for entry in self])
+
+
+def execute_command(cmd, runner=None, jobname=None):
+    """
+    Execute a command and return the exit status
+
+    Executes the supplied Command instance either
+    using the ``subprocess`` module, or via a
+    JobRunner instance (if one is supplied).
+
+    Arguments:
+      cmd (Command): command to execute
+      runner (JobRunner): optional, job runner
+        instance to use to execute the command
+      jobname (str): optional, name for the job
+        (if using a job runner)
+
+    Returns:
+      Integer: exit status of the executed command.
+    """
+    if jobname is None:
+        jobname = cmd.command
+    if runner is None:
+        # Job execution via subprocess
+        log = f"{jobname}.log"
+        try:
+            exit_code = cmd.run_subprocess(log=log)
+        finally:
+            # Print and remove log
+            if os.path.exists(log):
+                with open(log, "rt") as fp:
+                    print(fp.read())
+                os.remove(log)
+            return exit_code
+    else:
+        # Job execution via a runner
+        job = SchedulerJob(runner,
+                           cmd.command_line,
+                           name=f"{jobname}")
+        job.start()
+        try:
+            # Wait for job to finish
+            job.wait()
+        except KeyboardInterrupt as ex:
+            # Terminated by Ctrl-C
+            logger.warning(f"Keyboard interrupt: terminating "
+                           f"'{cmd.command} ...'")
+            job.terminate()
+        finally:
+            # Print and remove logs
+            for log in (job.log, job.err):
+                if log and os.path.exists(log):
+                    with open(log, "rt") as fp:
+                        print(fp.read())
+                    os.remove(log)
+        return job.exit_code
 
 
 def fmt_value(value, none='?'):

--- a/bcf_nanopore/utils.py
+++ b/bcf_nanopore/utils.py
@@ -273,6 +273,10 @@ def execute_command(cmd, runner=None, jobname=None):
     using the ``subprocess`` module, or via a
     JobRunner instance (if one is supplied).
 
+    Log files are written to the current directory
+    then echoed to stdout before deletion when
+    the command job has completed.
+
     Arguments:
       cmd (Command): command to execute
       runner (JobRunner): optional, job runner


### PR DESCRIPTION
Implements a new `-r`/`--runner` option on the `fetch` subcommand so the user can specify an appropriate job runner to use (if desired), for example:

    bcf_nanopore fetch -r SlurmRunner /mnt/data/PromethION_002 .

If the runner isn't supplied then the fetch `rsync` operations are executed locally.