### PR TITLE
Enable reporting of sample names for project analysis directories

### DIFF
--- a/bcf_nanopore/analysis.py
+++ b/bcf_nanopore/analysis.py
@@ -222,9 +222,9 @@ found in the primary data directory (renamed to identify the associated
 locations).""")
         # Report information
         print(self.report(mode="summary",
-                          fields="name,id,datestamp,platform,analysis_dir,,"
-                                 "user,pi,application,organism,primary_data,"
-                                 "comments"))
+                          fields="name,id,primary_data,analysis_dir,"
+                          "user,pi,application,organism,nsamples,"
+                          "sample_names"))
 
     def exists(self):
         """


### PR DESCRIPTION
Updates the `report` method of the `ProjectAnalysisDir` class (in the `analysis` module) to add a new field `sample_names` (aka `samples`) which can specified when reporting.

The `sample_names` field consists of a comma-separated list of sample names, or `?` if no sample information is available.

The PR also updates the fields reported by the `create` method when a new project analysis directory is made, to include the sample names.