### PR TITLE
'setup' command: specify parent directory

### DIFF
--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -155,6 +155,7 @@ def setup(project_dir, user, PI, application=None, organism=None,
     # Create analysis dir
     if top_dir is None:
         top_dir = os.getcwd()
+    top_dir = os.path.abspath(top_dir)
     analysis_dir = ProjectAnalysisDir(
         os.path.join(top_dir,
                      "%s_analysis" % project_name))

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -299,6 +299,9 @@ def bcf_nanopore_main():
                               "Promethion project")
     setup_cmd.add_argument('project_dir',
                            help="top level PromethION project directory")
+    setup_cmd.add_argument('parent_dir', nargs="?",
+                           help="create project analysis directory under "
+                           "PARENT_DIR (defaults to current directory)")
     setup_cmd.add_argument('-u', '--user', action='store', required=True,
                            help="User associated with project")
     setup_cmd.add_argument('-p', '--pi', action='store', required=True,
@@ -354,7 +357,7 @@ def bcf_nanopore_main():
     elif args.command == "setup":
         setup(args.project_dir, user=args.user, PI=args.pi,
               application=args.application, organism=args.organism,
-              samples_csv=args.samples_csv)
+              samples_csv=args.samples_csv, top_dir=args.parent_dir)
     elif args.command == "metadata":
         metadata(args.file, dump_json=args.json)
     elif args.command == "report":


### PR DESCRIPTION
Updates the `setup` command to add an optional "parent directory" (if specified then analysis directory is created under that directory rather the current directory).