### PR TITLE
Gracefully handle some CLI exceptions

### DIFF
--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -96,7 +96,10 @@ def metadata(metadata_file, dump_json=False):
     elif metadata_file.endswith(".json"):
         with open(metadata_file, "rt") as fp:
             data = json.load(fp)
-        print(json.dumps(data, sort_keys=True, indent=4))
+        try:
+            print(json.dumps(data, sort_keys=True, indent=4))
+        except BrokenPipeError:
+            pass
 
 
 def setup(project_dir, user, PI, application=None, organism=None,

--- a/bin/bcf_nanopore
+++ b/bin/bcf_nanopore
@@ -5,4 +5,7 @@
 #
 from bcf_nanopore.cli import bcf_nanopore_main
 if __name__ == "__main__":
-     bcf_nanopore_main()
+     try:
+          bcf_nanopore_main()
+     except KeyboardInterrupt:
+          pass


### PR DESCRIPTION
Updates the CLI to handle some exceptions more gracefully:

- Generally trap for keyboard interrupt (i.e. control-C)
- Specifically trap for broken pipe in the `metadata` command, when showing the JSON data