### PR TITLE
Add file types (i.e. POD5, BAM etc) to reported metadata

### DIFF
--- a/bcf_nanopore/analysis.py
+++ b/bcf_nanopore/analysis.py
@@ -140,21 +140,13 @@ class ProjectAnalysisDir:
                                        "%s.tsv" % self.info.name)
         fc_file = FlowcellBasecallsInfo()
         for fc in project.flow_cells:
-            reports = []
-            if fc.html_report:
-                reports.append("html")
-            if fc.json_report:
-                reports.append("json")
-            if reports:
-                reports = ",".join(reports)
-            else:
-                reports = None
             fc_file.add_base_calls(
                 run=("-" if fc.run is None else fc.run),
                 pool_name=fc.pool,
                 sub_dir=fc,
                 flow_cell_id=fc.id,
-                reports=fmt_value(reports),
+                reports=(",".join(fc.report_types)
+                         if fc.report_types else "none"),
                 kit=fmt_value(fc.metadata.kit),
                 modifications=("none"
                                if fc.metadata.modified_basecalling == "Off"
@@ -165,21 +157,13 @@ class ProjectAnalysisDir:
                 file_types=(",".join(fc.file_types)
                             if fc.file_types else "none"))
         for bc in project.basecalls_dirs:
-            reports = []
-            if bc.html_report:
-                reports.append("html")
-            if bc.json_report:
-                reports.append("json")
-            if reports:
-                reports = ",".join(reports)
-            else:
-                reports = None
             fc_file.add_base_calls(
                 run=("-" if bc.run is None else bc.run),
                 pool_name=(bc.pool if bc.pool else bc.name),
                 sub_dir=bc,
                 flow_cell_id=fmt_value(bc.metadata.flow_cell_id),
-                reports=fmt_value(reports),
+                reports=(",".join(bc.report_types)
+                         if bc.report_types else "none"),
                 kit=fmt_value(bc.metadata.kit),
                 modifications=("none"
                                if bc.metadata.modified_basecalling == "Off"

--- a/bcf_nanopore/analysis.py
+++ b/bcf_nanopore/analysis.py
@@ -565,7 +565,8 @@ class FlowcellBasecallsInfo(TabFile):
                         "Modifications",
                         "TrimBarcodes",
                         "MinknowVersion",
-                        "BasecallingModel")
+                        "BasecallingModel",
+                        "FileTypes")
         self._kws = tuple([convert_field_name(f)
                            for f in self._fields])
         TabFile.__init__(self,

--- a/bcf_nanopore/analysis.py
+++ b/bcf_nanopore/analysis.py
@@ -161,7 +161,9 @@ class ProjectAnalysisDir:
                                else fmt_value(fc.metadata.modifications)),
                 trim_barcodes=fmt_value(fc.metadata.trim_barcodes),
                 minknow_version=fc.metadata.software_versions["minknow"],
-                basecalling_model=fmt_value(fc.metadata.basecalling_model))
+                basecalling_model=fmt_value(fc.metadata.basecalling_model),
+                file_types=(",".join(fc.file_types)
+                            if fc.file_types else "none"))
         for bc in project.basecalls_dirs:
             reports = []
             if bc.html_report:
@@ -184,7 +186,9 @@ class ProjectAnalysisDir:
                                else fmt_value(bc.metadata.modifications)),
                 trim_barcodes=fmt_value(bc.metadata.trim_barcodes),
                 minknow_version=bc.metadata.software_versions["minknow"],
-                basecalling_model=fmt_value(bc.metadata.basecalling_model))
+                basecalling_model=fmt_value(bc.metadata.basecalling_model),
+                file_types=(",".join(bc.file_types)
+                            if bc.file_types else "none"))
         fc_file.save(flow_cells_file)
         # Get the earliest date stamp from flow cell names
         try:

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -40,7 +40,8 @@ def info(project_dir):
                      "Modifications",
                      "TrimBarcodes",
                      "MinKNOWVersion",
-                     "BasecallingModel"]))
+                     "BasecallingModel",
+                     "FileTypes"]))
     for fc in project.flow_cells:
         run = ("-" if fc.run is None else fc.run)
         kit = fmt_value(fc.metadata.kit)
@@ -60,6 +61,17 @@ def info(project_dir):
             reports = ",".join(reports)
         else:
             reports = "none"
+        file_types = []
+        if fc.pod5:
+            file_types.append("pod5")
+        if fc.bam_pass:
+            file_types.append("bam")
+        if fc.fastq_pass:
+            file_types.append("fastq")
+        if file_types:
+            file_types = ",".join(file_types)
+        else:
+            file_types = "none"
         basecalling_model = fc.metadata.basecalling_model
         if basecalling_model is None:
             basecalling_model = fc.metadata.basecalling_config
@@ -73,7 +85,8 @@ def info(project_dir):
                                           modifications,
                                           trim_barcodes,
                                           minknow_version,
-                                          basecalling_model)]))
+                                          basecalling_model,
+                                          file_types)]))
     for bc in project.basecalls_dirs:
         flow_cell_id = fmt_value(bc.metadata.flow_cell_id)
         run = ("-" if bc.run is None else bc.run)
@@ -98,6 +111,14 @@ def info(project_dir):
             reports = ",".join(reports)
         else:
             reports = "none"
+        if bc.pass_dir:
+            file_types = ["bam", "fastq"]
+        else:
+            file_types = []
+        if file_types:
+            file_types = ",".join(file_types)
+        else:
+            file_types = "none"
         basecalling_model = bc.metadata.basecalling_model
         if basecalling_model is None:
             basecalling_model = bc.metadata.basecalling_config
@@ -111,7 +132,8 @@ def info(project_dir):
                                           modifications,
                                           trim_barcodes,
                                           minknow_version,
-                                          basecalling_model)]))
+                                          basecalling_model,
+                                          file_types)]))
 
 
 def metadata(metadata_file, dump_json=False):

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -61,13 +61,7 @@ def info(project_dir):
             reports = ",".join(reports)
         else:
             reports = "none"
-        file_types = []
-        if fc.pod5:
-            file_types.append("pod5")
-        if fc.bam_pass:
-            file_types.append("bam")
-        if fc.fastq_pass:
-            file_types.append("fastq")
+        file_types = fc.file_types
         if file_types:
             file_types = ",".join(file_types)
         else:
@@ -111,10 +105,7 @@ def info(project_dir):
             reports = ",".join(reports)
         else:
             reports = "none"
-        if bc.pass_dir:
-            file_types = ["bam", "fastq"]
-        else:
-            file_types = []
+        file_types = bc.file_types
         if file_types:
             file_types = ",".join(file_types)
         else:

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -52,11 +52,7 @@ def info(project_dir):
             minknow_version = fc.metadata.software_versions["minknow"]
         except (TypeError, KeyError):
             minknow_version = "?"
-        reports = []
-        if fc.html_report:
-            reports.append("html")
-        if fc.json_report:
-            reports.append("json")
+        reports = fc.report_types
         if reports:
             reports = ",".join(reports)
         else:
@@ -96,11 +92,7 @@ def info(project_dir):
             minknow_version = bc.metadata.software_versions["minknow"]
         except (TypeError, KeyError):
             minknow_version = "?"
-        reports = []
-        if bc.html_report:
-            reports.append("html")
-        if bc.json_report:
-            reports.append("json")
+        reports = bc.report_types
         if reports:
             reports = ",".join(reports)
         else:

--- a/bcf_nanopore/nanopore/promethion.py
+++ b/bcf_nanopore/nanopore/promethion.py
@@ -134,6 +134,10 @@ class FlowCell:
         self.bam_pass = os.path.join(self.path, "bam_pass")
         if not os.path.exists(self.bam_pass):
             self.bam_pass = None
+        # FASTQs directory
+        self.fastq_pass = os.path.join(self.path, "fastq_pass")
+        if not os.path.exists(self.fastq_pass):
+            self.fastq_pass = None
         # Reports
         self.reports = []
         self.sample_sheet = None
@@ -189,10 +193,10 @@ class BasecallsDir:
         self.run = run
         # Associated metadata
         self.metadata = BasecallsMetadata()
-        # BAMs directory
-        self.bam_pass = os.path.join(self.path, "pass")
-        if not os.path.exists(self.bam_pass):
-            self.bam_pass = None
+        # BAMs and FASTQs directory
+        self.pass_dir = os.path.join(self.path, "pass")
+        if not os.path.exists(self.pass_dir):
+            self.pass_dir = None
         # Reports
         self.reports = []
         self.sample_sheet = None

--- a/bcf_nanopore/nanopore/promethion.py
+++ b/bcf_nanopore/nanopore/promethion.py
@@ -166,6 +166,15 @@ class FlowCell:
         return file_types
 
     @property
+    def report_types(self):
+        report_types = []
+        if self.html_report:
+            report_types.append("html")
+        if self.json_report:
+            report_types.append("json")
+        return report_types
+
+    @property
     def html_report(self):
         for f in self.reports:
             if f.endswith(".html"):
@@ -230,6 +239,15 @@ class BasecallsDir:
             return ["bam", "fastq"]
         else:
             return []
+
+    @property
+    def report_types(self):
+        report_types = []
+        if self.html_report:
+            report_types.append("html")
+        if self.json_report:
+            report_types.append("json")
+        return report_types
 
     @property
     def html_report(self):

--- a/bcf_nanopore/nanopore/promethion.py
+++ b/bcf_nanopore/nanopore/promethion.py
@@ -155,6 +155,17 @@ class FlowCell:
                 self.sample_sheet = f
 
     @property
+    def file_types(self):
+        file_types = []
+        if self.pod5:
+            file_types.append("pod5")
+        if self.bam_pass:
+            file_types.append("bam")
+        if self.fastq_pass:
+            file_types.append("fastq")
+        return file_types
+
+    @property
     def html_report(self):
         for f in self.reports:
             if f.endswith(".html"):
@@ -212,6 +223,13 @@ class BasecallsDir:
                               f"(ignored): {ex}")
             elif f.startswith("sample_sheet_"):
                 self.sample_sheet = f
+
+    @property
+    def file_types(self):
+        if self.pass_dir:
+            return ["bam", "fastq"]
+        else:
+            return []
 
     @property
     def html_report(self):

--- a/bcf_nanopore/test/nanopore/test_promethion.py
+++ b/bcf_nanopore/test/nanopore/test_promethion.py
@@ -72,6 +72,7 @@ class TestFlowCell(unittest.TestCase):
                          str(Path(flow_cell_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.json")))
         self.assertEqual(flow_cell.pod5,str(Path(flow_cell_dir).joinpath("pod5")))
         self.assertEqual(flow_cell.bam_pass, str(Path(flow_cell_dir).joinpath("bam_pass")))
+        self.assertEqual(flow_cell.fastq_pass, str(Path(flow_cell_dir).joinpath("fastq_pass")))
         self.assertEqual(str(flow_cell), "PG1-2/20240513_0829_1A_PAW15419_465bb23f")
         self.assertEqual(flow_cell.metadata.flow_cell_id, "PBC32212")
         self.assertEqual(flow_cell.metadata.flow_cell_type, "FLO-PRO114M")
@@ -111,6 +112,7 @@ class TestFlowCell(unittest.TestCase):
                          str(flow_cell_dir.joinpath("report_20240513_0829_1A_PAW15419_465bb23f.json")))
         self.assertEqual(flow_cell.pod5,str(flow_cell_dir.joinpath("pod5")))
         self.assertEqual(flow_cell.bam_pass, str(flow_cell_dir.joinpath("bam_pass")))
+        self.assertEqual(flow_cell.fastq_pass, str(flow_cell_dir.joinpath("fastq_pass")))
         self.assertEqual(str(flow_cell), "PG1-2/20240513_0829_1A_PAW15419_465bb23f")
         self.assertEqual(flow_cell.metadata.flow_cell_id, "PBC32212")
         self.assertEqual(flow_cell.metadata.flow_cell_type, "FLO-PRO114M")
@@ -147,7 +149,8 @@ class TestBasecallsDir(unittest.TestCase):
         self.assertEqual(basecalls.parent, "Rebasecalling")
         self.assertEqual(basecalls.pool, None)
         self.assertEqual(basecalls.run, None)
-        self.assertEqual(basecalls.bam_pass, str(Path(basecalls_dir).joinpath("pass")))
+        self.assertEqual(basecalls.pass_dir,
+                         str(Path(basecalls_dir).joinpath("pass")))
         self.assertEqual(basecalls.html_report,
                          str(Path(basecalls_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.html")))
         self.assertEqual(basecalls.json_report,
@@ -182,7 +185,8 @@ class TestBasecallsDir(unittest.TestCase):
         self.assertEqual(basecalls.parent, "Rebasecalling")
         self.assertEqual(basecalls.pool, "PG1-2")
         self.assertEqual(basecalls.run, "PG1-4_20240513")
-        self.assertEqual(basecalls.bam_pass, str(Path(basecalls_dir).joinpath("pass")))
+        self.assertEqual(basecalls.pass_dir,
+                         str(Path(basecalls_dir).joinpath("pass")))
         self.assertEqual(basecalls.html_report,
                          str(Path(basecalls_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.html")))
         self.assertEqual(basecalls.json_report,

--- a/bcf_nanopore/test/nanopore/test_promethion.py
+++ b/bcf_nanopore/test/nanopore/test_promethion.py
@@ -73,6 +73,7 @@ class TestFlowCell(unittest.TestCase):
         self.assertEqual(flow_cell.pod5,str(Path(flow_cell_dir).joinpath("pod5")))
         self.assertEqual(flow_cell.bam_pass, str(Path(flow_cell_dir).joinpath("bam_pass")))
         self.assertEqual(flow_cell.fastq_pass, str(Path(flow_cell_dir).joinpath("fastq_pass")))
+        self.assertEqual(flow_cell.file_types, ["pod5", "bam", "fastq"])
         self.assertEqual(str(flow_cell), "PG1-2/20240513_0829_1A_PAW15419_465bb23f")
         self.assertEqual(flow_cell.metadata.flow_cell_id, "PBC32212")
         self.assertEqual(flow_cell.metadata.flow_cell_type, "FLO-PRO114M")
@@ -113,6 +114,7 @@ class TestFlowCell(unittest.TestCase):
         self.assertEqual(flow_cell.pod5,str(flow_cell_dir.joinpath("pod5")))
         self.assertEqual(flow_cell.bam_pass, str(flow_cell_dir.joinpath("bam_pass")))
         self.assertEqual(flow_cell.fastq_pass, str(flow_cell_dir.joinpath("fastq_pass")))
+        self.assertEqual(flow_cell.file_types, ["pod5", "bam", "fastq"])
         self.assertEqual(str(flow_cell), "PG1-2/20240513_0829_1A_PAW15419_465bb23f")
         self.assertEqual(flow_cell.metadata.flow_cell_id, "PBC32212")
         self.assertEqual(flow_cell.metadata.flow_cell_type, "FLO-PRO114M")
@@ -151,6 +153,7 @@ class TestBasecallsDir(unittest.TestCase):
         self.assertEqual(basecalls.run, None)
         self.assertEqual(basecalls.pass_dir,
                          str(Path(basecalls_dir).joinpath("pass")))
+        self.assertEqual(basecalls.file_types, ["bam", "fastq"])
         self.assertEqual(basecalls.html_report,
                          str(Path(basecalls_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.html")))
         self.assertEqual(basecalls.json_report,
@@ -187,6 +190,7 @@ class TestBasecallsDir(unittest.TestCase):
         self.assertEqual(basecalls.run, "PG1-4_20240513")
         self.assertEqual(basecalls.pass_dir,
                          str(Path(basecalls_dir).joinpath("pass")))
+        self.assertEqual(basecalls.file_types, ["bam", "fastq"])
         self.assertEqual(basecalls.html_report,
                          str(Path(basecalls_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.html")))
         self.assertEqual(basecalls.json_report,

--- a/bcf_nanopore/test/nanopore/test_promethion.py
+++ b/bcf_nanopore/test/nanopore/test_promethion.py
@@ -70,6 +70,7 @@ class TestFlowCell(unittest.TestCase):
                          str(Path(flow_cell_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.html")))
         self.assertEqual(flow_cell.json_report,
                          str(Path(flow_cell_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.json")))
+        self.assertEqual(flow_cell.report_types, ["html", "json"])
         self.assertEqual(flow_cell.pod5,str(Path(flow_cell_dir).joinpath("pod5")))
         self.assertEqual(flow_cell.bam_pass, str(Path(flow_cell_dir).joinpath("bam_pass")))
         self.assertEqual(flow_cell.fastq_pass, str(Path(flow_cell_dir).joinpath("fastq_pass")))
@@ -111,6 +112,7 @@ class TestFlowCell(unittest.TestCase):
                          str(flow_cell_dir.joinpath("report_20240513_0829_1A_PAW15419_465bb23f.html")))
         self.assertEqual(flow_cell.json_report,
                          str(flow_cell_dir.joinpath("report_20240513_0829_1A_PAW15419_465bb23f.json")))
+        self.assertEqual(flow_cell.report_types, ["html", "json"])
         self.assertEqual(flow_cell.pod5,str(flow_cell_dir.joinpath("pod5")))
         self.assertEqual(flow_cell.bam_pass, str(flow_cell_dir.joinpath("bam_pass")))
         self.assertEqual(flow_cell.fastq_pass, str(flow_cell_dir.joinpath("fastq_pass")))
@@ -158,6 +160,7 @@ class TestBasecallsDir(unittest.TestCase):
                          str(Path(basecalls_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.html")))
         self.assertEqual(basecalls.json_report,
                          str(Path(basecalls_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.json")))
+        self.assertEqual(basecalls.report_types, ["html", "json"])
         self.assertEqual(basecalls.metadata.flow_cell_id, "PBC32212")
         self.assertEqual(basecalls.metadata.flow_cell_type, "FLO-PRO114M")
         self.assertEqual(basecalls.metadata.kit, "SQK-PCB114-24")
@@ -195,6 +198,7 @@ class TestBasecallsDir(unittest.TestCase):
                          str(Path(basecalls_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.html")))
         self.assertEqual(basecalls.json_report,
                          str(Path(basecalls_dir).joinpath("report_20240513_0829_1A_PAW15419_465bb23f.json")))
+        self.assertEqual(basecalls.report_types, ["html", "json"])
         self.assertEqual(basecalls.metadata.flow_cell_id, "PBC32212")
         self.assertEqual(basecalls.metadata.flow_cell_type, "FLO-PRO114M")
         self.assertEqual(basecalls.metadata.kit, "SQK-PCB114-24")

--- a/bcf_nanopore/test/test_analysis.py
+++ b/bcf_nanopore/test/test_analysis.py
@@ -171,7 +171,8 @@ class TestFlowcellBasecallsInfo(unittest.TestCase):
             modifications="none",
             trim_barcodes="Off",
             minknow_version="25.03.7",
-            basecalling_model="dna_r10.4.1_e8.2_400bps_hac@v4.3.0")
+            basecalling_model="dna_r10.4.1_e8.2_400bps_hac@v4.3.0",
+            file_types="pod5,bam")
         self.assertEqual(len(basecalls_info), 1)
         self.assertEqual(basecalls_info[0]["Run"], "Run1")
         self.assertEqual(basecalls_info[0]["PoolName"], "WT1_WT2_K27CL1_K27CL2")
@@ -182,6 +183,7 @@ class TestFlowcellBasecallsInfo(unittest.TestCase):
         self.assertEqual(basecalls_info[0]["Modifications"], "none")
         self.assertEqual(basecalls_info[0]["TrimBarcodes"], "Off")
         self.assertEqual(basecalls_info[0]["BasecallingModel"], "dna_r10.4.1_e8.2_400bps_hac@v4.3.0")
+        self.assertEqual(basecalls_info[0]["FileTypes"], "pod5,bam")
         # Save to file
         basecalls_file = os.path.join(self.wd, "basecalls.tsv")
         self.assertFalse(os.path.exists(basecalls_file))
@@ -191,8 +193,8 @@ class TestFlowcellBasecallsInfo(unittest.TestCase):
         with open(basecalls_file, "rt") as fp:
             contents = fp.read()
             self.assertEqual(contents,
-                             """#Run	PoolName	SubDir	FlowCellID	Reports	Kit	Modifications	TrimBarcodes	MinknowVersion	BasecallingModel
-Run1	WT1_WT2_K27CL1_K27CL2	WT1_WT2_K27CL1_K27CL2/20250616_0817_1F_PBC32212_40107e18	PBC32212	html,json	SQK-PCB114-24	none	Off	25.03.7	dna_r10.4.1_e8.2_400bps_hac@v4.3.0
+                             """#Run	PoolName	SubDir	FlowCellID	Reports	Kit	Modifications	TrimBarcodes	MinknowVersion	BasecallingModel	FileTypes
+Run1	WT1_WT2_K27CL1_K27CL2	WT1_WT2_K27CL1_K27CL2/20250616_0817_1F_PBC32212_40107e18	PBC32212	html,json	SQK-PCB114-24	none	Off	25.03.7	dna_r10.4.1_e8.2_400bps_hac@v4.3.0	pod5,bam
 """)
 
     def test_flowcell_basecalls_info_read_from_file(self):
@@ -201,8 +203,8 @@ Run1	WT1_WT2_K27CL1_K27CL2	WT1_WT2_K27CL1_K27CL2/20250616_0817_1F_PBC32212_40107
         """
         basecalls_file = os.path.join(self.wd, "basecalls.tsv")
         with open(basecalls_file, "wt") as fp:
-            fp.write("""#Run	PoolName	SubDir	FlowCellID	Reports	Kit	Modifications	TrimBarcodes	MinknowVersion	BasecallingModel
-Run1	WT1_WT2_K27CL1_K27CL2	WT1_WT2_K27CL1_K27CL2/20250616_0817_1F_PBC32212_40107e18	PBC32212	html,json	SQK-PCB114-24	none	Off	25.03.7	dna_r10.4.1_e8.2_400bps_hac@v4.3.0
+            fp.write("""#Run	PoolName	SubDir	FlowCellID	Reports	Kit	Modifications	TrimBarcodes	MinknowVersion	BasecallingModel	FileTypes
+Run1	WT1_WT2_K27CL1_K27CL2	WT1_WT2_K27CL1_K27CL2/20250616_0817_1F_PBC32212_40107e18	PBC32212	html,json	SQK-PCB114-24	none	Off	25.03.7	dna_r10.4.1_e8.2_400bps_hac@v4.3.0	pod5,bam
 """)
         basecalls_info = FlowcellBasecallsInfo(basecalls_file)
         self.assertEqual(len(basecalls_info), 1)
@@ -215,6 +217,7 @@ Run1	WT1_WT2_K27CL1_K27CL2	WT1_WT2_K27CL1_K27CL2/20250616_0817_1F_PBC32212_40107
         self.assertEqual(basecalls_info[0]["Modifications"], "none")
         self.assertEqual(basecalls_info[0]["TrimBarcodes"], "Off")
         self.assertEqual(basecalls_info[0]["BasecallingModel"], "dna_r10.4.1_e8.2_400bps_hac@v4.3.0")
+        self.assertEqual(basecalls_info[0]["FileTypes"], "pod5,bam")
 
     def test_flowcell_basecalls_info_read_from_file_no_minknow_version_or_basecalling_model(self):
         """
@@ -237,3 +240,4 @@ Run1	WT1_WT2_K27CL1_K27CL2	WT1_WT2_K27CL1_K27CL2/20250616_0817_1F_PBC32212_40107
         self.assertEqual(basecalls_info[0]["TrimBarcodes"], "Off")
         self.assertEqual(basecalls_info[0]["MinknowVersion"], "")
         self.assertEqual(basecalls_info[0]["BasecallingModel"], "")
+        self.assertEqual(basecalls_info[0]["FileTypes"], "")


### PR DESCRIPTION
Updates the `info` command to report the file types that have been found in the flowcell and basecalling directories (i.e. POD5, BAM, FASTQ). Also updates the metadata associated with the `ProjectAnalysisDir` to include this information.

Changes include the addition of new `file_types` and `report_types` properties on the `FlowCell` and `BasecallsDir` classes in `nanopore/promethion`.