### PR TITLE
Add basic configuration options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,19 @@ environment using ``pip``, e.g.
 
 *NB please use these instructions only as a starting point*
 
+Configuration
+-------------
+
+The installed package can be configured via an ``.ini``-style file
+called ``bcf_nanopore.ini`` placed either in the current directory
+or in the ``config`` directory of the package installation.
+
+.. note::
+
+   A sample version of the config file called
+   ``bcf_nanopore.ini.sample``can be found in the ``config``
+   directory.
+
 Usage
 -----
 
@@ -44,6 +57,7 @@ To get general help run:
 
 The main commands are:
 
+* ``config``: print current configuration information
 * ``info``: reports information about a PromethION project directory
   containing outputs from one or more runs of the sequencer
 * ``setup``: creates an "analysis" directory for a PromethION

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -409,6 +409,7 @@ def bcf_nanopore_main():
                             "than stdout")
 
     # Fetch command
+    default_runner = __settings.runners.rsync
     fetch_cmd = sp.add_parser("fetch",
                               help="fetch BAM files from PromethION project "
                               "directory")

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -20,6 +20,20 @@ from .utils import fmt_yes_no
 # Configuration
 __settings = Settings()
 
+# Reporting templates
+REPORTING_TEMPLATES = {
+    # Default: for spreadsheet
+    'default': "name,id,NULL,NULL,user,pi,application,organism,NULL,"
+    "nsamples,samples,NULL,NULL,NULL",
+    # BCF: for downstream spreadsheet
+    'bcf': "datestamp,NULL,user,id,#samples,NULL,organism,application,PI,analysis_dir,NULL,primary_data",
+    # Summary: for reporting run for downstream analysis
+    'summary': "name,id,datestamp,platform,analysis_dir,NULL,"
+    "user,pi,application,organism,primary_data,comments",
+}
+for t in [t for t in __settings.reporting_templates]:
+    REPORTING_TEMPLATES[t] = __settings.reporting_templates[t]
+
 def config():
     """
     Print configuration information
@@ -240,29 +254,14 @@ def report(path, mode="summary", fields=None, template=None, out_file=None):
     """
     Report on Promethion project analysis directory
     """
-    # Templates
-    _templates = {
-        # Default: for spreadsheet
-        'default':
-        "name,id,NULL,NULL,user,pi,application,organism,NULL,"
-        "nsamples,samples,NULL,NULL,NULL",
-        # BCF: for downstream spreadsheet
-        'bcf': "datestamp,NULL,user,id,#samples,NULL,organism,application,PI,analysis_dir,NULL,primary_data",
-        # Summary: for reporting run for downstream analysis
-        'summary': "name,id,datestamp,platform,analysis_dir,NULL,"
-        "user,pi,application,organism,primary_data,comments",
-    }
     # Read in data
     analysis_dir = ProjectAnalysisDir(path)
     # Set fields
     if fields is None:
         if template is None:
-            if mode == "summary":
-                template = "summary"
-            else:
-                template = "default"
+            template = "default"
         try:
-            fields = _templates[template]
+            fields = REPORTING_TEMPLATES[template]
         except KeyError:
             raise Exception("%s: undefined template" % template)
     # Report
@@ -398,7 +397,7 @@ def bcf_nanopore_main():
                             choices=['summary', 'tsv'], default='summary',
                             help="specify reporting mode")
     report_cmd.add_argument('-t', '--template',
-                            choices=['default', 'bcf', 'summary'],
+                            choices=[t for t in REPORTING_TEMPLATES],
                             help="specify template used to set fields "
                             "for reporting")
     report_cmd.add_argument('-f', '--fields',

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -12,9 +12,20 @@ from bcftbx.JobRunner import fetch_runner
 from .analysis import ProjectAnalysisDir
 from .nanopore.promethion import BasecallsMetadata
 from .nanopore.promethion import ProjectDir
+from .settings import Settings
 from .utils import execute_command
 from .utils import fmt_value
 from .utils import fmt_yes_no
+
+# Configuration
+__settings = Settings()
+
+def config():
+    """
+    Print configuration information
+    """
+    settings = Settings(resolve_undefined=True)
+    print(settings.report_settings(exclude_undefined=False))
 
 
 def info(project_dir):
@@ -336,6 +347,10 @@ def bcf_nanopore_main():
     p = ArgumentParser()
     sp = p.add_subparsers(dest='command')
 
+    # Config command
+    config_cmd = sp.add_parser("config",
+                               help="Print configuration information")
+
     # Info command
     info_cmd = sp.add_parser("info",
                              help="Get information on a Promethion project "
@@ -405,12 +420,16 @@ def bcf_nanopore_main():
     fetch_cmd.add_argument('--dry-run', action="store_true",
                            help="dry run only (no data will be copied)")
     fetch_cmd.add_argument('-r', '--runner', action="store",
-                           help="job runner to use (optional)")
+                           default=default_runner,
+                           help=f"job runner to use (default: "
+                           f"'{default_runner}')")
 
     # Process command line
     args = p.parse_args()
 
     # Execute command
+    if args.command == "config":
+        config()
     if args.command == "info":
         info(args.project_dir)
     elif args.command == "setup":

--- a/bcf_nanopore/settings.py
+++ b/bcf_nanopore/settings.py
@@ -1,0 +1,86 @@
+#!/bin/env python
+#
+#     settings.py: handle package configuration
+#     Copyright (C) University of Manchester 2025 Peter Briggs
+#
+
+"""
+Module for handling package configuration information from
+settings for automated processing from '.ini'-style config
+files.
+
+Provides the following classes:
+
+- Settings: handle configuration for 'bcf_nanopore' package
+"""
+
+#######################################################################
+# Imports
+#######################################################################
+
+import os
+from auto_process_ngs.settings import GenericSettings
+from auto_process_ngs.settings import locate_settings_file
+from auto_process_ngs.settings import get_config_dir
+from auto_process_ngs.settings import jobrunner
+
+#######################################################################
+# Classes
+#######################################################################
+
+class Settings(GenericSettings):
+    """
+    Handle local configuration for ``bcf_nanopore``
+
+    By default tries to locate a configuration file
+    called ``bcf_nanopore.ini`` by checking the
+    following locations:
+
+    1. Current directory
+    2. Config directory of the installation
+
+    Arguments:
+      settings_file (str): path to configuration file to
+        read settings from (optional)
+      resolve_undefined (bool): if True (default) then
+        assign values to "null" parameters by checking
+        fallback parameters and default values
+    """
+    def __init__(self, settings_file=None, resolve_undefined=True):
+        GenericSettings.__init__(
+            self,
+            # Define the sections, parameters and types
+            settings = {
+                "general": { "default_runner": jobrunner },
+                "runners": { "rsync": jobrunner },
+                "reporting_templates": { "*": str },
+            },
+            # Defaults
+            defaults = {
+                "general.default_runner": "SimpleJobRunner"
+            },
+            # Fallbacks
+            fallbacks = {
+                "runners.*": "general.default_runner"
+            },
+            # Configuration file
+            settings_file=self._find_config(settings_file),
+            resolve_undefined=resolve_undefined)
+
+    def _find_config(self, settings_file=None):
+        """
+        Locate settings file to load values from
+
+        Arguments:
+          settings_file (str): if set then use this
+            as the settings file; otherwise attempt
+            locate a file by searching the default
+            locations
+        """
+        if settings_file is None:
+            # Look for default
+            settings_file = locate_settings_file(
+                "bcf_nanopore.ini",
+                paths=[os.getcwd(),
+                       get_config_dir()])
+        return settings_file

--- a/bcf_nanopore/test/test_settings.py
+++ b/bcf_nanopore/test/test_settings.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# Tests for the 'analysis' module
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from bcftbx.JobRunner import SimpleJobRunner,GEJobRunner
+from bcf_nanopore.settings import Settings
+
+
+class TestSettings(unittest.TestCase):
+
+    def setUp(self):
+        # Create a temp working dir
+        self.wd = tempfile.mkdtemp(suffix="TestSettings")
+
+    def tearDown(self):
+        if Path(self.wd).exists():
+            shutil.rmtree(self.wd)
+
+    def test_settings_defaults(self):
+        """
+        Settings: default settings (no .ini file)
+        """
+        s = Settings()
+        # General settings
+        self.assertTrue(isinstance(s.general.default_runner,
+                                   SimpleJobRunner))
+        # Runners
+        self.assertTrue(isinstance(s.runners.rsync,
+                                   SimpleJobRunner))
+        # Reporting templates
+
+    def test_settings_from_config_file(self):
+        """
+        Settings: load settings from config .ini file
+        """
+        settings_file = Path(self.wd).joinpath("bcf_nanopore.ini")
+        with open(settings_file, "wt") as fp:
+            fp.write("""[general]
+default_runner = SimpleJobRunner
+
+[runners]
+rsync = SimpleJobRunner(nslots=4)
+""")
+        # Load settings
+        s = Settings(settings_file)
+        # General settings
+        self.assertTrue(isinstance(s.general.default_runner,
+                                   SimpleJobRunner))
+        # Runners
+        self.assertTrue(isinstance(s.runners.rsync,
+                                   SimpleJobRunner))
+        self.assertEqual(s.runners.rsync.nslots, 4)
+
+    def test_settings_reporting_templates(self):
+        """
+        Settings: load reporting templates from config .ini file
+        """
+        settings_file = Path(self.wd).joinpath("bcf_nanopore.ini")
+        with open(settings_file, "wt") as fp:
+            fp.write("""[reporting_templates]
+default = name,id,user,pi,application,organism,nsamples,samples
+bcf = datestamp,NULL,user,id,#samples,NULL,organism,application,PI,analysis_dir,NULL,primary_data
+""")
+        # Load settings
+        s = Settings(settings_file)
+        # Reporting templates
+        self.assertEqual([name for name in s.reporting_templates],
+                         ["default", "bcf"])
+        self.assertEqual(s.reporting_templates.default,
+                         "name,id,user,pi,application,organism,"
+                         "nsamples,samples")
+        self.assertEqual(s.reporting_templates.bcf,
+                         "datestamp,NULL,user,id,#samples,NULL,organism,"
+                         "application,PI,analysis_dir,NULL,primary_data")

--- a/config/bcf_nanopore.ini.sample
+++ b/config/bcf_nanopore.ini.sample
@@ -1,0 +1,14 @@
+# Configuration file for bcf_nanopore
+#
+# General configuration
+;[general]
+;default_runner = SimpleJobRunner
+
+# Define runners for specific jobs
+;[runners]
+;rsync = SimpleJobRunner
+
+# Templates for reporting
+# Assign fields to template names for reporting projects
+;[reporting_templates]
+;bcf = datestamp,NULL,user,id,#samples,NULL,organism,application,PI,analysis_dir,NULL,primary_data

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name = "bcf_nanopore",
       # Scripts
       scripts = scripts,
       # Sample configuration file
-      #data_files = [("config" ,["config/bcf_nanopore.ini.sample"]),],
+      data_files = [("config", ["config/bcf_nanopore.ini.sample"]),],
       classifiers=[
           "Development Status :: 2 - Pre-Alpha",
           "Environment :: Console",


### PR DESCRIPTION
Updates the package so that it can be configured for the local site using a `bcf_nanopore.ini` file:

1. Adds a new module `settings` which implements a `Settings` class (subclassed from the `GenericSettings` class from `auto_process_ngs`) to define basic configuration options
2. Adds a sample `bcf_nanopore.ini.sample` file in a new `config` subdir, which is added to the installation when `setup.py` is used to install the package
3. Implements a new `config` command to print the local configuration (if any)
4. Updates the `fetch` command to use the job runner defined in the configuration
5. Updates the `report` command to allow use of custom reporting templates defined in the configuration

Closes #10.