### PR TITLE
Set permissions and group in 'fetch' and 'setup' commands

### DIFF
--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -516,7 +516,8 @@ def bcf_nanopore_main():
     elif args.command == "setup":
         setup(args.project_dir, user=args.user, PI=args.pi,
               application=args.application, organism=args.organism,
-              samples_csv=args.samples_csv, top_dir=args.parent_dir)
+              samples_csv=args.samples_csv, top_dir=args.parent_dir,
+              permissions=args.permissions, group=args.group)
     elif args.command == "metadata":
         metadata(args.file, dump_json=args.json)
     elif args.command == "report":
@@ -524,4 +525,5 @@ def bcf_nanopore_main():
                template=args.template, out_file=args.out_file)
     elif args.command == "fetch":
         fetch(args.project_dir, args.dest, dry_run=args.dry_run,
-              runner=args.runner, permissions=args.permissions)
+              runner=args.runner, permissions=args.permissions,
+              group=args.group)

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -465,6 +465,7 @@ def bcf_nanopore_main():
     # Fetch command
     default_runner = __settings.runners.rsync
     default_permissions = __settings.general.permissions
+    default_group = __settings.general.group
     fetch_cmd = sp.add_parser("fetch",
                               help="fetch BAM files from PromethION project "
                               "directory")
@@ -481,6 +482,12 @@ def bcf_nanopore_main():
                            "'chmod' command (e.g. 'o-rwX') (default: %s)" %
                            (f"'{default_permissions}'" if default_permissions
                             else "don't set permissions",))
+    fetch_cmd.add_argument('--group', action='store',
+                           default=default_group,
+                           help="specify the name of group for the copied "
+                           "files (default: %s)" %
+                           (f"'{default_group}'" if default_group
+                            else "don't set group",))
     fetch_cmd.add_argument('--dry-run', action="store_true",
                            help="dry run only (no data will be copied)")
     fetch_cmd.add_argument('-r', '--runner', action="store",

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -390,6 +390,10 @@ def fetch(project_dir, target_dir, dry_run=False, runner=None,
 
 def bcf_nanopore_main():
 
+    # Defaults
+    default_permissions = __settings.general.permissions
+    default_group = __settings.general.group
+
     # Main parser
     p = ArgumentParser()
     sp = p.add_subparsers(dest='command')
@@ -415,7 +419,6 @@ def bcf_nanopore_main():
                         "items")
 
     # Setup command
-    default_permissions = __settings.general.permissions
     setup_cmd = sp.add_parser("setup",
                               help="Set up a new analysis directory for a "
                               "Promethion project")
@@ -444,6 +447,12 @@ def bcf_nanopore_main():
                            "'o-rwX') (default: %s)" %
                            (f"'{default_permissions}'" if default_permissions
                             else "don't set permissions",))
+    setup_cmd.add_argument('--group', action='store',
+                           default=default_group,
+                           help="specify the name of group for the "
+                           "analysis directory (default: %s)" %
+                           (f"'{default_group}'" if default_group
+                            else "don't set group",))
 
     # Report command
     report_cmd = sp.add_parser("report",
@@ -467,8 +476,6 @@ def bcf_nanopore_main():
 
     # Fetch command
     default_runner = __settings.runners.rsync
-    default_permissions = __settings.general.permissions
-    default_group = __settings.general.group
     fetch_cmd = sp.add_parser("fetch",
                               help="fetch BAM files from PromethION project "
                               "directory")

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -296,7 +296,8 @@ def report(path, mode="summary", fields=None, template=None, out_file=None):
         print(report_text)
 
 
-def fetch(project_dir, target_dir, dry_run=False, runner=None):
+def fetch(project_dir, target_dir, dry_run=False, runner=None,
+          permissions=None):
     """
     Fetch the BAM files and reports for a Promethion run
 
@@ -309,6 +310,9 @@ def fetch(project_dir, target_dir, dry_run=False, runner=None):
         (default is to actually fetch the data)
       runner (str): job runner definition to use to
         execute the fetch operations
+      permissions (str): update file permissions on the
+        copied files and directories using the supplied
+        mode (e.g. 'g+w')
     """
     # Clean the project dir path
     project_dir = project_dir.rstrip(os.sep)
@@ -334,8 +338,10 @@ def fetch(project_dir, target_dir, dry_run=False, runner=None):
                         '--include=bam_pass/*/*.bai',
                         '--include=pass/*/*.bam',
                         '--include=pass/*/*.bai',
-                        '--exclude=*',
-                        project_dir,
+                        '--exclude=*')
+    if permissions:
+        rsync_bams.add_args(f"--chmod={permissions}")
+    rsync_bams.add_args(project_dir,
                         target_dir)
     print("Transferring BAM files with command: %s" % rsync_bams)
     status = execute_command(rsync_bams, runner=runner)
@@ -353,8 +359,10 @@ def fetch(project_dir, target_dir, dry_run=False, runner=None):
                            '--include=*/',
                            '--include=report_*',
                            '--include=sample_sheet_*',
-                           '--exclude=*',
-                           project_dir,
+                           '--exclude=*')
+    if permissions:
+        rsync_reports.add_args(f"--chmod={permissions}")
+    rsync_reports.add_args(project_dir,
                            target_dir)
     print("Transferring report files with command: %s" % rsync_reports)
     status = execute_command(rsync_reports, runner=runner)

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -11,6 +11,7 @@ import shutil
 from argparse import ArgumentParser
 from auto_process_ngs.command import Command
 from auto_process_ngs.fileops import copy
+from auto_process_ngs.fileops import set_permissions
 from bcftbx.JobRunner import fetch_runner
 from .analysis import ProjectAnalysisDir
 from .nanopore.promethion import BasecallsMetadata
@@ -186,7 +187,7 @@ def metadata(metadata_file, dump_json=False):
 
 
 def setup(project_dir, user, PI, application=None, organism=None,
-          samples_csv=None, top_dir=None):
+          samples_csv=None, top_dir=None, permissions=None):
     """
     Set up a new analysis directory for a Promethion project
 
@@ -209,6 +210,9 @@ def setup(project_dir, user, PI, application=None, organism=None,
       samples_csv (str): path to CSV file with sample information
       top_dir (str): directory to make analysis directory
         under (defaults to current directory)
+      permissions (str): update file permissions on the
+        copied files and directories using the supplied
+        mode (e.g. 'g+w')
     """
     # Read source project data
     project_name = os.path.basename(os.path.normpath(project_dir))
@@ -251,6 +255,9 @@ def setup(project_dir, user, PI, application=None, organism=None,
                         application=application,
                         organism=organism,
                         samples=samples)
+    # Set permissions
+    if permissions:
+        set_permissions(permissions, analysis_dir.path)
 
 
 def report(path, mode="summary", fields=None, template=None, out_file=None):

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -11,6 +11,7 @@ import shutil
 from argparse import ArgumentParser
 from auto_process_ngs.command import Command
 from auto_process_ngs.fileops import copy
+from auto_process_ngs.fileops import set_group
 from auto_process_ngs.fileops import set_permissions
 from bcftbx.JobRunner import fetch_runner
 from .analysis import ProjectAnalysisDir
@@ -304,7 +305,7 @@ def report(path, mode="summary", fields=None, template=None, out_file=None):
 
 
 def fetch(project_dir, target_dir, dry_run=False, runner=None,
-          permissions=None):
+          permissions=None, group=None):
     """
     Fetch the BAM files and reports for a Promethion run
 
@@ -320,6 +321,8 @@ def fetch(project_dir, target_dir, dry_run=False, runner=None,
       permissions (str): update file permissions on the
         copied files and directories using the supplied
         mode (e.g. 'g+w')
+      group (str): update the filesystem group associated
+        with the copied files to the supplied group name
     """
     # Clean the project dir path
     project_dir = project_dir.rstrip(os.sep)
@@ -375,6 +378,11 @@ def fetch(project_dir, target_dir, dry_run=False, runner=None,
     status = execute_command(rsync_reports, runner=runner)
     if status != 0:
         raise Exception("fetch: failed to transfer reports")
+    # Set the group
+    if group is not None:
+        print(f"Setting group on copied files to '{group}'")
+        if not dry_run:
+            set_group(group, os.path.join(target_dir, project_name))
 
 
 def bcf_nanopore_main():

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -404,6 +404,7 @@ def bcf_nanopore_main():
                         "items")
 
     # Setup command
+    default_permissions = __settings.general.permissions
     setup_cmd = sp.add_parser("setup",
                               help="Set up a new analysis directory for a "
                               "Promethion project")
@@ -423,6 +424,15 @@ def bcf_nanopore_main():
     setup_cmd.add_argument('-s', '--samples_csv', action='store',
                            help="CSV file with 'sample,barcode[,flowcell]' "
                            "information")
+    setup_cmd.add_argument('--chmod', action="store",
+                           dest="permissions", metavar="PERMISSIONS",
+                           default=default_permissions,
+                           help="specify permissions for the analysis "
+                           "directory. PERMISSIONS should be a string "
+                           "recognised by the 'chmod' command (e.g. "
+                           "'o-rwX') (default: %s)" %
+                           (f"'{default_permissions}'" if default_permissions
+                            else "don't set permissions",))
 
     # Report command
     report_cmd = sp.add_parser("report",

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -439,6 +439,7 @@ def bcf_nanopore_main():
 
     # Fetch command
     default_runner = __settings.runners.rsync
+    default_permissions = __settings.general.permissions
     fetch_cmd = sp.add_parser("fetch",
                               help="fetch BAM files from PromethION project "
                               "directory")
@@ -447,6 +448,14 @@ def bcf_nanopore_main():
     fetch_cmd.add_argument('dest',
                            help="destination directory (copy of top-level "
                            "directory will be created under this)")
+    fetch_cmd.add_argument('--chmod', action="store",
+                           dest="permissions", metavar="PERMISSIONS",
+                           default=default_permissions,
+                           help="specify permissions for the copied files. "
+                           "PERMISSIONS should be a string recognised by the "
+                           "'chmod' command (e.g. 'o-rwX') (default: %s)" %
+                           (f"'{default_permissions}'" if default_permissions
+                            else "don't set permissions",))
     fetch_cmd.add_argument('--dry-run', action="store_true",
                            help="dry run only (no data will be copied)")
     fetch_cmd.add_argument('-r', '--runner', action="store",
@@ -473,4 +482,4 @@ def bcf_nanopore_main():
                template=args.template, out_file=args.out_file)
     elif args.command == "fetch":
         fetch(args.project_dir, args.dest, dry_run=args.dry_run,
-              runner=args.runner)
+              runner=args.runner, permissions=args.permissions)

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -188,7 +188,7 @@ def metadata(metadata_file, dump_json=False):
 
 
 def setup(project_dir, user, PI, application=None, organism=None,
-          samples_csv=None, top_dir=None, permissions=None):
+          samples_csv=None, top_dir=None, permissions=None, group=None):
     """
     Set up a new analysis directory for a Promethion project
 
@@ -212,8 +212,9 @@ def setup(project_dir, user, PI, application=None, organism=None,
       top_dir (str): directory to make analysis directory
         under (defaults to current directory)
       permissions (str): update file permissions on the
-        copied files and directories using the supplied
-        mode (e.g. 'g+w')
+        analysis directory using the supplied mode (e.g. 'g+w')
+      group (str): update the filesystem group associated
+        with the analysis directory to the supplied group name
     """
     # Read source project data
     project_name = os.path.basename(os.path.normpath(project_dir))
@@ -256,9 +257,11 @@ def setup(project_dir, user, PI, application=None, organism=None,
                         application=application,
                         organism=organism,
                         samples=samples)
-    # Set permissions
+    # Set permissions and group
     if permissions:
         set_permissions(permissions, analysis_dir.path)
+    if group:
+        set_group(group, analysis_dir.path)
 
 
 def report(path, mode="summary", fields=None, template=None, out_file=None):

--- a/bcf_nanopore/settings.py
+++ b/bcf_nanopore/settings.py
@@ -51,7 +51,9 @@ class Settings(GenericSettings):
             self,
             # Define the sections, parameters and types
             settings = {
-                "general": { "default_runner": jobrunner },
+                "general": { "default_runner": jobrunner,
+                             "permissions": str,
+                             "group": str },
                 "runners": { "rsync": jobrunner },
                 "reporting_templates": { "*": str },
             },

--- a/bcf_nanopore/test/test_cli.py
+++ b/bcf_nanopore/test/test_cli.py
@@ -90,6 +90,36 @@ PG4,NB06,
         self.assertTrue(Path(analysis_dir_path).joinpath("ScriptCode").is_dir())
         self.assertTrue(Path(analysis_dir_path).joinpath("logs").is_dir())
 
+    def test_setup_set_permissions(self):
+        """
+        setup: create new analysis directory (set permissions)
+        """
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f", run="PG1-4_20240513", pool="PG1-2")
+        data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
+                                   flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
+        project_dir = data_dir.create(self.wd)
+        analysis_dir_path = str(Path(self.wd).joinpath("PromethION_Project_001_PerGynt_analysis"))
+        cli_setup(project_dir, "Per Gynt", "Henrik Ibsen", "Methylation study",
+                  "Human", top_dir=self.wd, permissions="ugo+rwX")
+        analysis_dir = ProjectAnalysisDir(analysis_dir_path)
+        self.assertTrue(analysis_dir.exists())
+        self.assertEqual(analysis_dir.path, analysis_dir_path)
+        self.assertEqual(analysis_dir.info.name, "PromethION_Project_001_PerGynt")
+        self.assertEqual(analysis_dir.info.id, "PROMETHION#001")
+        self.assertEqual(analysis_dir.info.platform, "promethion")
+        self.assertEqual(analysis_dir.info.data_dir, project_dir)
+        self.assertEqual(analysis_dir.info.user, "Per Gynt")
+        self.assertEqual(analysis_dir.info.PI, "Henrik Ibsen")
+        self.assertEqual(analysis_dir.info.application, "Methylation study")
+        self.assertEqual(analysis_dir.info.organism, "Human")
+        self.assertTrue(Path(analysis_dir_path).joinpath("README").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("project.info").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("basecalling.tsv").exists())
+        self.assertFalse(Path(analysis_dir_path).joinpath("samples.tsv").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("ScriptCode").is_dir())
+        self.assertTrue(Path(analysis_dir_path).joinpath("logs").is_dir())
+
 
 class TestFetchCommand(unittest.TestCase):
 

--- a/bcf_nanopore/test/test_cli.py
+++ b/bcf_nanopore/test/test_cli.py
@@ -151,6 +151,23 @@ class TestFetchCommand(unittest.TestCase):
         cli_fetch(project_dir, target_dir, runner="SimpleJobRunner(join_logs=True)")
         self.assertTrue(Path(target_dir).joinpath("PromethION_Project_001_PerGynt").exists())
 
+    def test_fetch_set_permissions(self):
+        """
+        fetch: copy PromethION data (set permissions)
+        """
+        # Make source data
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f", run="PG1-4_20240513", pool="PG1-2")
+        data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
+                                   flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
+        source_dir = os.path.join(self.wd, "source")
+        os.mkdir(source_dir)
+        project_dir = data_dir.create(source_dir)
+        # Fetch subset
+        target_dir = os.path.join(self.wd, "target")
+        cli_fetch(project_dir, target_dir, permissions="ugo+rwX")
+        self.assertTrue(Path(target_dir).joinpath("PromethION_Project_001_PerGynt").exists())
+
 
 class TestReportCommand(unittest.TestCase):
 

--- a/bcf_nanopore/test/test_cli.py
+++ b/bcf_nanopore/test/test_cli.py
@@ -122,6 +122,54 @@ PG4,NB06,
         self.assertTrue(Path(analysis_dir_path).joinpath("ScriptCode").is_dir())
         self.assertTrue(Path(analysis_dir_path).joinpath("logs").is_dir())
 
+    def test_setup_set_group(self):
+        """
+        setup: create new analysis directory (set group)
+        """
+        # Find groups for current user
+        current_user = pwd.getpwuid(os.getuid()).pw_name
+        groups = [g.gr_gid
+                  for g in grp.getgrall()
+                  if current_user in g.gr_mem]
+        if len(groups) < 2:
+            raise unittest.SkipTest(f"user '{current_user}' must be in at "
+                                    "least two groups for this test")
+        # Find a group to set archived files to
+        current_gid = os.stat(self.wd).st_gid
+        new_group = None
+        for gid in groups:
+            if gid != current_gid:
+                new_group = gid
+                break
+        self.assertTrue(new_group is not None)
+        # Create mock PromethION project
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f", run="PG1-4_20240513", pool="PG1-2")
+        data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
+                                   flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
+        project_dir = data_dir.create(self.wd)
+        analysis_dir_path = str(Path(self.wd).joinpath("PromethION_Project_001_PerGynt_analysis"))
+        cli_setup(project_dir, "Per Gynt", "Henrik Ibsen", "Methylation study",
+                  "Human", top_dir=self.wd, group=new_group)
+        analysis_dir = ProjectAnalysisDir(analysis_dir_path)
+        self.assertTrue(analysis_dir.exists())
+        self.assertEqual(analysis_dir.path, analysis_dir_path)
+        self.assertEqual(analysis_dir.info.name, "PromethION_Project_001_PerGynt")
+        self.assertEqual(analysis_dir.info.id, "PROMETHION#001")
+        self.assertEqual(analysis_dir.info.platform, "promethion")
+        self.assertEqual(analysis_dir.info.data_dir, project_dir)
+        self.assertEqual(analysis_dir.info.user, "Per Gynt")
+        self.assertEqual(analysis_dir.info.PI, "Henrik Ibsen")
+        self.assertEqual(analysis_dir.info.application, "Methylation study")
+        self.assertEqual(analysis_dir.info.organism, "Human")
+        self.assertTrue(Path(analysis_dir_path).joinpath("README").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("project.info").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("basecalling.tsv").exists())
+        self.assertFalse(Path(analysis_dir_path).joinpath("samples.tsv").exists())
+        self.assertTrue(Path(analysis_dir_path).joinpath("ScriptCode").is_dir())
+        self.assertTrue(Path(analysis_dir_path).joinpath("logs").is_dir())
+        self.assertEqual(Path(analysis_dir_path).stat().st_gid, new_group)
+
 
 class TestFetchCommand(unittest.TestCase):
 

--- a/bcf_nanopore/test/test_cli.py
+++ b/bcf_nanopore/test/test_cli.py
@@ -3,6 +3,8 @@
 # Tests for the 'cli' module
 
 import os
+import pwd
+import grp
 import shutil
 import tempfile
 import unittest
@@ -197,6 +199,42 @@ class TestFetchCommand(unittest.TestCase):
         target_dir = os.path.join(self.wd, "target")
         cli_fetch(project_dir, target_dir, permissions="ugo+rwX")
         self.assertTrue(Path(target_dir).joinpath("PromethION_Project_001_PerGynt").exists())
+
+    def test_fetch_set_group(self):
+        """
+        fetch: copy PromethION data (set group)
+        """
+        # Find groups for current user
+        current_user = pwd.getpwuid(os.getuid()).pw_name
+        groups = [g.gr_gid
+                  for g in grp.getgrall()
+                  if current_user in g.gr_mem]
+        if len(groups) < 2:
+            raise unittest.SkipTest(f"user '{current_user}' must be in at "
+                                    "least two groups for this test")
+        # Find a group to set archived files to
+        current_gid = os.stat(self.wd).st_gid
+        new_group = None
+        for gid in groups:
+            if gid != current_gid:
+                new_group = gid
+                break
+        self.assertTrue(new_group is not None)
+        # Make source data
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f", run="PG1-4_20240513", pool="PG1-2")
+        data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
+                                   flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
+        source_dir = os.path.join(self.wd, "source")
+        os.mkdir(source_dir)
+        project_dir = data_dir.create(source_dir)
+        # Fetch subset
+        target_dir = os.path.join(self.wd, "target")
+        cli_fetch(project_dir, target_dir, group=new_group)
+        self.assertTrue(Path(target_dir).joinpath(
+            "PromethION_Project_001_PerGynt").exists())
+        self.assertEqual(
+            Path(target_dir).joinpath("PromethION_Project_001_PerGynt").stat().st_gid, new_group)
 
 
 class TestReportCommand(unittest.TestCase):

--- a/config/bcf_nanopore.ini.sample
+++ b/config/bcf_nanopore.ini.sample
@@ -3,6 +3,8 @@
 # General configuration
 ;[general]
 ;default_runner = SimpleJobRunner
+;permissions = None
+;group = None
 
 # Define runners for specific jobs
 ;[runners]


### PR DESCRIPTION
Updates the `fetch` and `setup` commands to set the permissions and group ownership on their outputs.

Default permissions and group can be set in the configuration file via the `permissions` and `group` parameters in the `[general]` section (`permissions` should be a string that is accepted by the `chmod` command, `group` should be a valid filesystem group); otherwise the permissions and/or group can be overridden by setting them via the `--chmod` and `--group` options for both commands.