### PR TITLE
`fetch`: fix bug when JobRunner instance is supplied

### DIFF
--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -12,6 +12,7 @@ from argparse import ArgumentParser
 from auto_process_ngs.command import Command
 from auto_process_ngs.fileops import copy
 from bcftbx.JobRunner import fetch_runner
+from bcftbx.JobRunner import BaseJobRunner
 from .analysis import ProjectAnalysisDir
 from .nanopore.promethion import BasecallsMetadata
 from .nanopore.promethion import ProjectDir
@@ -315,9 +316,9 @@ def fetch(project_dir, target_dir, dry_run=False, runner=None):
     # Project name
     project_name = os.path.basename(project_dir)
     # Fetch job runner
-    if runner is not None:
-        runner = fetch_runner(runner)
-        print(f"Using job runner '{runner}'")
+    if runner is not None and not isinstance(runner, BaseJobRunner):
+            runner = fetch_runner(runner)
+    print(f"Using job runner '{runner}'")
     # Example rsync to only fetch BAM and index files:
     # rsync --dry-run -av -m --include="*/" \
     # --include="bam_pass/*/*.bam" --include="bam_pass/*/*.bai" \


### PR DESCRIPTION
Fixes a bug in the `fetch` command when a JobRunner instance is supplied (e.g. from the configuration settings) rather than a definition string (from the command line).

Closes #24.