### PR TITLE
Report "full" relative paths to flowcell & basecalling subdirectories

### DIFF
--- a/bcf_nanopore/analysis.py
+++ b/bcf_nanopore/analysis.py
@@ -143,7 +143,7 @@ class ProjectAnalysisDir:
             fc_file.add_base_calls(
                 run=("-" if fc.run is None else fc.run),
                 pool_name=fc.pool,
-                sub_dir=fc,
+                sub_dir=os.path.relpath(fc.path, project.path),
                 flow_cell_id=fc.id,
                 reports=(",".join(fc.report_types)
                          if fc.report_types else "none"),
@@ -160,7 +160,7 @@ class ProjectAnalysisDir:
             fc_file.add_base_calls(
                 run=("-" if bc.run is None else bc.run),
                 pool_name=(bc.pool if bc.pool else bc.name),
-                sub_dir=bc,
+                sub_dir=os.path.relpath(bc.path, project.path),
                 flow_cell_id=fmt_value(bc.metadata.flow_cell_id),
                 reports=(",".join(bc.report_types)
                          if bc.report_types else "none"),

--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -96,7 +96,8 @@ def info(project_dir):
         basecalling_model = fmt_value(basecalling_model)
         print('\t'.join([str(s) for s in (run,
                                           fc.pool,
-                                          fc,
+                                          os.path.relpath(fc.path,
+                                                          project.path),
                                           fc.id,
                                           reports,
                                           kit,
@@ -136,7 +137,8 @@ def info(project_dir):
         basecalling_model = fmt_value(basecalling_model)
         print('\t'.join([str(s) for s in (run,
                                           pool,
-                                          bc,
+                                          os.path.relpath(bc.path,
+                                                          project.path),
                                           flow_cell_id,
                                           reports,
                                           kit,


### PR DESCRIPTION
Updates reporting of the subdirectory paths to the flowcell and basecalling directories within a project, so that the subdirectory is now the "full" relative path to the top-level PromethION project directory. (Previously only a partial path was reported.)

This affects the output of the `info` command, and the metadata written by the `setup` command (via the `ProjectAnalysisDir.create()` method in the `analysis` module).