### PR TITLE
`fetch` include sequencing summary files

### DIFF
--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -363,10 +363,10 @@ def fetch(project_dir, target_dir, dry_run=False, runner=None,
     status = execute_command(rsync_bams, runner=runner)
     if status != 0:
         raise Exception("fetch: failed to transfer data")
-    # Example to fetch reports and sample sheets:
+    # Example to fetch reports, sample sheets and summaries:
     # rsync --dry-run -av -m --include="*/" --include="report_*" \
-    # --include="sample_sheet_*" --exclude="*" \
-    # <PromethION_PROJECT_DIR> .
+    # --include="sample_sheet_*" --include="sequencing_summary*.txt" \
+    # --exclude="*" <PromethION_PROJECT_DIR> .
     rsync_reports = Command('rsync')
     if dry_run:
         rsync_reports.add_args('--dry-run')
@@ -375,6 +375,7 @@ def fetch(project_dir, target_dir, dry_run=False, runner=None,
                            '--include=*/',
                            '--include=report_*',
                            '--include=sample_sheet_*',
+                           '--include=sequencing_summary*.txt',
                            '--exclude=*')
     if permissions:
         rsync_reports.add_args(f"--chmod={permissions}")


### PR DESCRIPTION
Updates the `fetch` command to include sequencing summary files (e.g. `sequencing_summary.txt`) when copying reports and other additional data.

These might be useful as they can be used as input for external QC software (see issue #29).