### PR TITLE
`fetch` allows custom file type sets to be specified for copy

### DIFF
--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -513,6 +513,13 @@ def bcf_nanopore_main():
     fetch_cmd.add_argument('dest',
                            help="destination directory (copy of top-level "
                            "directory will be created under this)")
+    fetch_cmd.add_argument('--files', action="store",
+                           dest="file_types", metavar="FILETYPES",
+                           default="bam",
+                           help="specify types of data files to copy "
+                           "as a comma-separated list (e.g. 'fastq,bams') "
+                           "(valid types are 'pod5', 'fastq', 'bams'; "
+                           "default: 'bam')")
     fetch_cmd.add_argument('--chmod', action="store",
                            dest="permissions", metavar="PERMISSIONS",
                            default=default_permissions,
@@ -553,6 +560,7 @@ def bcf_nanopore_main():
         report(args.analysis_dir, mode=args.mode, fields=args.fields,
                template=args.template, out_file=args.out_file)
     elif args.command == "fetch":
-        fetch(args.project_dir, args.dest, dry_run=args.dry_run,
-              runner=args.runner, permissions=args.permissions,
-              group=args.group)
+        fetch(args.project_dir, args.dest,
+              file_types=[x for x in str(args.file_types).split(",")],
+              dry_run=args.dry_run, runner=args.runner,
+              permissions=args.permissions, group=args.group)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -100,15 +100,28 @@ Usage:
 
 ::
 
-   bcf_nanopore fetch PROJECT DEST
+   bcf_nanopore fetch PROJECT DEST [--files FILETYPES]
    
 Copies a subset of the Promethion output data from ``PROJECT``
 under ``DEST``.
 
 ``PROJECT`` can be a local or remote directory.
 
-The subset currently consists of BAM files from the basecalling
-plus any report files found in the source.
+By default the subset consists of BAM files from the basecalling
+plus any report files found in the source; the ``--files`` option
+can be used to specify the set of file types, for example:
+
+::
+
+   --files pod5,fastq,bam
+
+will copy POD5, FASTQ and BAM files, whereas
+
+::
+
+   --files fastq,bam
+
+will only copy FASTQ and BAM files.
 
 ----------
 ``report``


### PR DESCRIPTION
Updates the `fetch` command with a new `--files` option which allows the user to specify which files types are included in the copy (POD5, FASTQ and BAM).

For example:

    bcf_nanopore fetch --files pod5,fastq

will copy the POD5 and FASTQ files.

If file types are not explicitly specified via this option then the default is only to copy BAM files.