### PR TITLE
'settings': update function call for locating the configuration file

### DIFF
--- a/bcf_nanopore/settings.py
+++ b/bcf_nanopore/settings.py
@@ -84,5 +84,5 @@ class Settings(GenericSettings):
             settings_file = locate_settings_file(
                 "bcf_nanopore.ini",
                 paths=[os.getcwd(),
-                       get_config_dir()])
+                       get_config_dir(__file__)])
         return settings_file


### PR DESCRIPTION
Updates the call for locating the configuration file in the `settings` module to match the latest version of the `get_config_dir` function (from `auto_process_ngs.settings`) (needs the path to the module in the current package).

Closes #36.