### PR TITLE
Fix 'fetch' command for projects without 'barcode...' subdirectories.

### DIFF
--- a/bcf_nanopore/cli.py
+++ b/bcf_nanopore/cli.py
@@ -523,8 +523,8 @@ def bcf_nanopore_main():
                            dest="file_types", metavar="FILETYPES",
                            default="bam",
                            help="specify types of data files to copy "
-                           "as a comma-separated list (e.g. 'fastq,bams') "
-                           "(valid types are 'pod5', 'fastq', 'bams'; "
+                           "as a comma-separated list (e.g. 'fastq,bam') "
+                           "(valid types are 'pod5', 'fastq', 'bam'; "
                            "default: 'bam')")
     fetch_cmd.add_argument('--chmod', action="store",
                            dest="permissions", metavar="PERMISSIONS",


### PR DESCRIPTION
Fixes the `fetch` command when copying data for projects where the Fastq, BAM and POD5 files in the `*_pass` directories don't have an intermediate barcode level.

The fix is to modify the wildcards used in the `rsync` `--include=...` options, so that it can handle cases where there are arbitrary intermediate subdirectory levels between the `*_pass` directory and the files of interest.

Closes #40.