### PR TITLE
Enable reporting of datestamps with "short" (2-digit) years

### DIFF
--- a/bcf_nanopore/analysis.py
+++ b/bcf_nanopore/analysis.py
@@ -660,6 +660,30 @@ The following files have been automatically generated:
         except IndexError:
             return None
 
+    def datestamp_short(self, run=None):
+        """
+        Fetch "short" datestamp for project or run
+
+        The short version of the datestamp has a 2-digit year
+        instead a 4-digit year (e.g. "260310" instead of
+        "20260310").
+
+        Args:
+            run:
+
+        Returns:
+            run (str): optional, specifies run to get datestamp for
+
+        Returns:
+            str: earliest associated datestamp extracted from
+            flow cell directories within project or run
+        """
+        datestamp = self.datestamp(run)
+        if datestamp and len(datestamp) == 8:
+            return datestamp[2:]
+        else:
+            return datestamp
+
     @staticmethod
     def _make_project_id(name):
         """

--- a/bcf_nanopore/analysis.py
+++ b/bcf_nanopore/analysis.py
@@ -469,6 +469,7 @@ The following files have been automatically generated:
         - name (project name)
         - id (project ID)
         - datestamp (earliest associated flow cell datestamp)
+        - datestamp_short (datestamp with 2-digit year)
         - nruns (number of runs)
         - #runs (alias for 'nruns')
         - runs (comma-separated list of run names)
@@ -477,6 +478,7 @@ The following files have been automatically generated:
         - pi (associated PIs)
         - run (name of run)
         - run_datestamp (datestamp of run)
+        - run_datestamp_short (datestamp of run with 2-digit year)
         - nsamples (number of samples)
         - #samples (alias for 'nsamples')
         - samples (comma-separated list of sample names)
@@ -536,10 +538,16 @@ The following files have been automatically generated:
             value = self.info.id
         elif field == "datestamp":
             value = self.datestamp()
+        elif field == "datestamp_short":
+            value = self.datestamp_short()
         elif field == "run_datestamp":
             if run is None:
                 raise KeyError(f"'{field}' field requires a run name")
             value = self.datestamp(run)
+        elif field == "run_datestamp_short":
+            if run is None:
+                raise KeyError(f"'{field}' field requires a run name")
+            value = self.datestamp_short(run)
         elif field == "run":
             if run is None:
                 raise KeyError(f"'{field}' field requires a run name")

--- a/bcf_nanopore/test/test_analysis.py
+++ b/bcf_nanopore/test/test_analysis.py
@@ -67,6 +67,8 @@ class TestProjectAnalysisDir(unittest.TestCase):
         # Check datestamps
         self.assertEqual(analysis_dir.datestamp(), "20240513")
         self.assertEqual(analysis_dir.datestamp("PG1-4_20240513"), "20240513")
+        self.assertEqual(analysis_dir.datestamp_short(), "240513")
+        self.assertEqual(analysis_dir.datestamp_short("PG1-4_20240513"), "240513")
 
     def test_project_analysis_dir_create_multiple_runs(self):
         """
@@ -118,6 +120,9 @@ class TestProjectAnalysisDir(unittest.TestCase):
         self.assertEqual(analysis_dir.datestamp(), "20240513")
         self.assertEqual(analysis_dir.datestamp("PG1-2_20240513"), "20240513")
         self.assertEqual(analysis_dir.datestamp("PG3-4_20240529"), "20240529")
+        self.assertEqual(analysis_dir.datestamp_short(), "240513")
+        self.assertEqual(analysis_dir.datestamp_short("PG1-2_20240513"), "240513")
+        self.assertEqual(analysis_dir.datestamp_short("PG3-4_20240529"), "240529")
 
     def test_project_analysis_dir_create_custom_project_metadata(self):
         """
@@ -176,6 +181,8 @@ class TestProjectAnalysisDir(unittest.TestCase):
         # Check datestamps
         self.assertEqual(analysis_dir.datestamp(), "20240513")
         self.assertEqual(analysis_dir.datestamp("PG1-4_20240513"), "20240513")
+        self.assertEqual(analysis_dir.datestamp_short(), "240513")
+        self.assertEqual(analysis_dir.datestamp_short("PG1-4_20240513"), "240513")
 
     def test_project_analysis_dir_create_custom_run_metadata(self):
         """
@@ -232,6 +239,8 @@ class TestProjectAnalysisDir(unittest.TestCase):
         # Check datestamps
         self.assertEqual(analysis_dir.datestamp(), "20240513")
         self.assertEqual(analysis_dir.datestamp("PG1-4_20240513"), "20240513")
+        self.assertEqual(analysis_dir.datestamp_short(), "240513")
+        self.assertEqual(analysis_dir.datestamp_short("PG1-4_20240513"), "240513")
 
     def test_project_analysis_dir_update_with_new_runs(self):
         """
@@ -278,6 +287,8 @@ class TestProjectAnalysisDir(unittest.TestCase):
         # Check datestamps
         self.assertEqual(analysis_dir.datestamp(), "20240513")
         self.assertEqual(analysis_dir.datestamp("PG1-2_20240513"), "20240513")
+        self.assertEqual(analysis_dir.datestamp_short(), "240513")
+        self.assertEqual(analysis_dir.datestamp_short("PG1-2_20240513"), "240513")
         # Add new run with extra flowcell and basecalls
         data_dir.add_flow_cell("20240529_0830_1A_PAW17328_523ce32d",
                                relpath=Path("PG3-4_20240529").joinpath("PG3-4"))
@@ -301,6 +312,9 @@ class TestProjectAnalysisDir(unittest.TestCase):
         self.assertEqual(analysis_dir.datestamp(), "20240513")
         self.assertEqual(analysis_dir.datestamp("PG1-2_20240513"), "20240513")
         self.assertEqual(analysis_dir.datestamp("PG3-4_20240529"), "20240529")
+        self.assertEqual(analysis_dir.datestamp_short(), "240513")
+        self.assertEqual(analysis_dir.datestamp_short("PG1-2_20240513"), "240513")
+        self.assertEqual(analysis_dir.datestamp_short("PG3-4_20240529"), "240529")
 
     def test_project_analysis_dir_load_existing(self):
         """

--- a/bcf_nanopore/test/test_analysis.py
+++ b/bcf_nanopore/test/test_analysis.py
@@ -750,6 +750,29 @@ class TestProjectAnalysisDir(unittest.TestCase):
             analysis_dir.report_project_runs("name,run,#samples,user,pi,analysts,order_numbers"),
             "PromethION_Project_001_PerGynt\tPG1-2_20240513\t2\tPer Gynt\tHenrik Ibsen\tSam Beckett\t#00123")
 
+    def test_project_analysis_dir_single_run_report_project_runs_datestamps(self):
+        """
+        ProjectAnalysisDir: handle datestamps when reporting runs
+        """
+        data_dir = "/mnt/data/PromethION_Project_001_PerGynt"
+        analysis_dir = MockProjectAnalysisDir("PromethION_Project_001_PerGynt_analysis",)
+        analysis_dir.add_run("PG1-2_20240513",
+                             samples={"PG1": ("NB03", "PAW14589"),
+                                      "PG2": ("NB04", "PAW14589")},)
+        analysis_dir_path = analysis_dir.create(
+            self.wd,
+            user="Per Gynt",
+            principal_investigator="Henrik Ibsen",
+            application="Methylation study",
+            organism="Human",
+            data_dir=data_dir,
+            project_id="PROMETHION#001")
+        analysis_dir = ProjectAnalysisDir(analysis_dir_path)
+        self.assertEqual(
+            analysis_dir.report_project_runs(
+                "datestamp,datestamp_short,run_datestamp,run_datestamp_short,name,run,#samples"),
+            "20240513\t240513\t20240513\t240513\tPromethION_Project_001_PerGynt\tPG1-2_20240513\t2")
+
 
 class TestFlowcellBasecallsInfo(unittest.TestCase):
 

--- a/config/bcf_nanopore.ini.sample
+++ b/config/bcf_nanopore.ini.sample
@@ -18,4 +18,4 @@
 # Templates for reporting
 # Assign fields to template names for reporting projects
 ;[reporting_templates]
-;bcf = datestamp,NULL,user,id,#samples,NULL,organism,application,PI,analysis_dir,NULL,primary_data
+;bcf = datestamp_short,NULL,user,id,#samples,NULL,organism,application,PI,analysis_dir,NULL,primary_data


### PR DESCRIPTION
Updates the reporting of project analysis directories to add "short" datestamps (i.e. datestamps with 2-digit rather than 4-digit years, e.g. `240510` instead of `20240510`).

The PR implements the following changes:

* `ProjectAnalysisDir` class (in the `analysis` module) updated to add new `datestamp_short` method (returns the shortened datestamps), and
* `get_value` method of the same class updated to recognise new `datestamp_short` and `run_datestamp_short` fields, which can then be specified in templates sent to the `report` method.

The changes are intended to enable reporting of datestamps consistent with the 2-digit year datestamps from Illumina sequencer outputs in `auto-process-ngs`.