### PR TITLE
Bug fix for exception when loading project with "flowcell-like" subdirectories

### DIFF
--- a/bcf_nanopore/nanopore/promethion.py
+++ b/bcf_nanopore/nanopore/promethion.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 #     nanopore.promethion: library for for managing ONT PromethION data
-#     Copyright (C) University of Manchester 2024-2025 Peter Briggs
+#     Copyright (C) University of Manchester 2024-2026 Peter Briggs
 #
 
 """
@@ -119,9 +119,12 @@ class RunDir:
                     break
         print("...located %d flow cell directories" % len(flow_cell_dirs))
         for d in flow_cell_dirs:
-            print("...adding flow cell '%s'" % d)
-            fc = FlowCell(d, run=self.name)
-            self.flow_cells.append(fc)
+            try:
+                print("...adding flow cell '%s'" % d)
+                fc = FlowCell(d, run=self.name)
+                self.flow_cells.append(fc)
+            except Exception as e:
+                print(f"... failed to add flow cell ({e})")
         self.flow_cells = sorted(self.flow_cells, key=lambda x: x.name)
         print("...located %d base calls directories" % len(basecalls_dirs))
         for d in basecalls_dirs:

--- a/bcf_nanopore/test/nanopore/test_promethion.py
+++ b/bcf_nanopore/test/nanopore/test_promethion.py
@@ -63,6 +63,22 @@ class TestProjectDir(unittest.TestCase):
         self.assertEqual(project.name, "PromethION_Project_001_PerGynt")
         self.assertEqual(len(project.flow_cells), 3)
 
+    def test_project_dir_non_flowcell_subdirectory(self):
+        """
+        ProjectDir: load from directory with non-flowcell subdirectory
+        """
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        # Add a run
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f",
+                               relpath=Path("PG1-4_20240513").joinpath("PG1-2"))
+        project_dir = data_dir.create(self.wd)
+        # Add a non-flowcell subdirectory
+        Path(project_dir).joinpath("my_batch_symlinks", "bam_pass").mkdir(parents=True)
+        # Load the data
+        project = ProjectDir(project_dir)
+        self.assertEqual(project.name, "PromethION_Project_001_PerGynt")
+        self.assertEqual(len(project.flow_cells), 1)
+
 class TestRunDir(unittest.TestCase):
 
     def setUp(self):

--- a/bcf_nanopore/test/test_cli.py
+++ b/bcf_nanopore/test/test_cli.py
@@ -44,6 +44,22 @@ class TestInfoCommand(unittest.TestCase):
         project_dir = data_dir.create(self.wd)
         cli_info(project_dir)
 
+    def test_info_handle_non_flowcell_subdir(self):
+        """
+        info: handle non-flowcell subdirectory in project
+        """
+
+        data_dir = MockPromethionDataDir("PromethION_Project_001_PerGynt")
+        data_dir.add_flow_cell("20240513_0829_1A_PAW15419_465bb23f",
+                               relpath=Path("PG1-4_20240513").joinpath("PG1-2"))
+        data_dir.add_basecalls_dir(str(Path("PG1-4_20240513").joinpath("Rebasecalling","PG1-2")),
+                                   flow_cell_name="20240513_0829_1A_PAW15419_465bb23f")
+        project_dir = data_dir.create(self.wd)
+        # Add a non-flowcell subdirectory
+        Path(project_dir).joinpath("my_batch_symlinks", "bam_pass").mkdir(parents=True)
+        # Run the 'info' command
+        cli_info(project_dir)
+
 class TestSetupCommand(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Fixes a bug in the `RunDir` class of `nanopore/promethion.py` when trying to load data from a "flowcell-like" subdirectory (for example, `.../my_batch_symlinks/bam_pass/...`).

In this case, attempting to load the data fails with an exception:

    Traceback (most recent call last):
      File "XXXX/bcf_nanopore/main/bin/bcf_nanopore", line 9, in <module>
        bcf_nanopore_main()
      File "XXXX/bcf_nanopore/main/bcf_nanopore/cli.py", line 753, in bcf_nanopore_main
        info(args.project_dir)
      File "XXXX/bcf_nanopore/main/bcf_nanopore/cli.py", line 121, in info
        project = ProjectDir(os.path.abspath(project_dir))
      File "XXXX/bcf_nanopore/main/bcf_nanopore/nanopore/promethion.py", line 60, in __init__
        run = RunDir(str(d))
      File "XXXX/bcf_nanopore/main/bcf_nanopore/nanopore/promethion.py", line 123, in __init__
        fc = FlowCell(d, run=self.name)
      File "XXXX/bcf_nanopore/main/bcf_nanopore/nanopore/promethion.py", line 150, in __init__
        raise Exception("'%s': not a flow cell name?" % self.name)
    Exception: 'my_batch_symlinks': not a flow cell name?

The fix traps for the exception, reports the issue, and ignores the offending subdirectory.