### PR TITLE
Bugfix for 'modifications' metadata item containing newlines and non-ASCII special characters

### DIFF
--- a/bcf_nanopore/nanopore/promethion.py
+++ b/bcf_nanopore/nanopore/promethion.py
@@ -416,7 +416,14 @@ class BasecallsMetadata:
             for name in ("modifications", "modified_base_context"):
                 self.modifications = self._fetch_item(settings, name)
                 if self.modifications:
-                    break                         
+                    # Clean up special characters
+                    self.modifications = "".join([c for c in self.modifications
+                                                  if ord(c) in range(128)])
+                    # Transform newlines into commas
+                    self.modifications = self.modifications.replace("\n", ",")
+                    # Remove leading/trailing whitespace
+                    self.modifications = self.modifications.strip()
+                    break
         else:
             self.modifications = None
         try:


### PR DESCRIPTION
Updates the handling of the `modifications` metadata item extracted from the HTML JSON data in the `load_from_report_html` method of the `BasecallsMetadata` class, to clean up and remove non-ASCII characters and newlines.

Closes #61.